### PR TITLE
fixed python lfg j and k logic

### DIFF
--- a/readMe.txt
+++ b/readMe.txt
@@ -82,15 +82,6 @@ TODO:
     LCG and Lehmer not scaling properly:
         set this->maxValue in algorithm header constructor
 
-    LFG fails with 2-digit j or k values
-        **(I added a safeguard to the src/visual_utils.py getAlgoArgs() to only allow i,k = 1-9
-           but this can be removed if this was a bug and gets fixed)
-        *(fix python interaction with LFG to account for j and k rules,
-            - j!=k, 
-            - j>0, 
-            - k>0
-        )*
-
     Rule30 only giving 1's (at least with default seed)
         - maybe need to change default seed for rule30
 

--- a/src/visuals_utils.py
+++ b/src/visuals_utils.py
@@ -175,11 +175,11 @@ def getAlgoArgs(algo):
         while op_char not in ['*', '+', '-', '^']:
             op_char = input("Invalid Input -- Select From Operators (*, +, -, ^): ")
         j = -1
-        while not (j > 0 and j < 10):
-            j = getIntFromInput("J Value (1-9): ")
+        while not (j > 0):
+            j = getIntFromInput("J Value: ")
         k = -1
-        while not (k > 0 and k < 10):
-            k = getIntFromInput("K Value (1-9): ")
+        while not (k > 0 and k != j):
+            k = getIntFromInput("K Value: ")
         
         return [op_char, j, k]
     


### PR DESCRIPTION
can now use lfg algo with any integer instead of just 1-9